### PR TITLE
Version 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 1.3.1 for Minecraft 1.16.x
+
+*Built with forge 1.16.4 35.0.4, compatible with 1.16.1 - 1.16.4*
+- Used an access modifier to get the Horse you're interacting with. It should fix all the issues that you had.
+
 ## Version 1.3.0 for Minecraft 1.16.x
 
 - Added "displayMinMax" option. When turned off, it won't display the min and max statistics

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'eclipse'
 apply plugin: 'maven-publish'
 
-version = 'MC1.16.x-1.3.0'
+version = 'MC1.16.x-1.3.1'
 group = 'dev.nero.horsestatsmod' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'horsestatsmod'
 
@@ -29,7 +29,7 @@ minecraft {
     mappings channel: 'snapshot', version: '20200514-1.16'
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     
-    // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
+    accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
     // Default run configurations.
     // These can be tweaked, removed, or duplicated as needed.
@@ -56,7 +56,7 @@ dependencies {
     // Specify the version of Minecraft to use, If this is any group other then 'net.minecraft' it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency. And it's patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.16.3-34.1.0'
+    minecraft 'net.minecraftforge:forge:1.16.4-35.0.14'
 
     // You may put jars on which you depend on in ./libs or you may define them like so..
     // compile "some.group:artifact:version:classifier"

--- a/src/main/java/dev/nero/horsestatsmod/HorseStatsMod.java
+++ b/src/main/java/dev/nero/horsestatsmod/HorseStatsMod.java
@@ -62,7 +62,6 @@ public class HorseStatsMod
     private void onEntityInteractEvent(final PlayerInteractEvent.EntityInteractSpecific event) {
         if (event.getTarget() instanceof AbstractHorseEntity) {
             if (!((AbstractHorseEntity) event.getTarget()).isTame()) {
-
                 this.getHorseStats((AbstractHorseEntity) event.getTarget());
 
                 Minecraft.getInstance().ingameGUI.setOverlayMessage(
@@ -121,27 +120,11 @@ public class HorseStatsMod
         if (event.getGuiContainer() instanceof HorseInventoryScreen) {
             // 1. GET THE STATISTICS OF THAT RIDDEN HORSE
 
-            // The horse attribute is private in HorseInventoryScreen, and the event does not have the information
-            // either (that's normal because that's a render event). So we need to retrieve it using an other way
-            AbstractHorseEntity horse = null;
-            try {
-                // If the player is riding it
-                horse = (AbstractHorseEntity) Minecraft.getInstance().player.getRidingEntity();
-            } catch (Exception e1) {
-                // If the player is interacting with it by crouching + right clicking it
-                try {
-                    horse = (AbstractHorseEntity) Minecraft.getInstance().pointedEntity;
-                } catch (Exception e2) {
-                    LOGGER.error("Could not get the horse information");
-                }
-            }
-
-            if (horse == null) return;
-
+            // The horse attribute is private in HorseInventoryScreen (see accesstransformer.cfg)
+            AbstractHorseEntity horse = ((HorseInventoryScreen) event.getGuiContainer()).horseEntity;
             getHorseStats(horse);
 
             // 2. DISPLAY THE STATS
-
             // Mouse position (relative to the top left of the container) to know when to render the hovering text
             // This - 2*blabla shifts the mouse position so that (0, 0) is actually the top left of the container
             // Why event.getGuiContainer().getGuiLeft() is not already the left position of the container? I have

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,2 @@
+# private final AbstractHorseEntity horseEntity; -> public
+public net.minecraft.client.gui.screen.inventory.HorseInventoryScreen field_147034_x

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -5,7 +5,7 @@ issueTrackerURL="https://github.com/N3ROO/HorseStatsMod/issues" #optional
 
 [[mods]] #mandatory
 modId="horsestatsmod" #mandatory
-version="1.3.0" #mandatory
+version="1.3.1" #mandatory
 displayName="Horse Stats Mod" #mandatory
 updateJSONURL="https://raw.githubusercontent.com/N3ROO/HorseStatsMod/MC_1.16.3/update.json" #optional
 displayURL="https://github.com/N3ROO/HorseStatsMod" #optional

--- a/update.json
+++ b/update.json
@@ -2,11 +2,11 @@
 {
   "homepage": "https://github.com/N3ROO/HorseStatsMod/releases",
   "promos": {
-    "1.16.3-latest": "1.3.0",
-    "1.16.3-recommended": "1.3.0",
-    "1.16.2-latest": "1.3.0",
-    "1.16.2-recommended": "1.3.0",
-    "1.16.1-latest": "1.3.0",
-    "1.16.1-recommended": "1.3.0"
+    "1.16.3-latest": "1.3.1",
+    "1.16.3-recommended": "1.3.1",
+    "1.16.2-latest": "1.3.1",
+    "1.16.2-recommended": "1.3.1",
+    "1.16.1-latest": "1.3.1",
+    "1.16.1-recommended": "1.3.1"
   }
 }


### PR DESCRIPTION
## Version 1.3.1 for Minecraft 1.16.x

*Built with forge 1.16.4 35.0.4, compatible with 1.16.1 - 1.16.4*
- Used an access modifier to get the Horse you're interacting with. It should fix all the issues that you had.